### PR TITLE
Remove unused `buildHostedView`

### DIFF
--- a/Templates/SATS/SwiftUI Screen.xctemplate/___FILEBASENAME___AdapterController.swift
+++ b/Templates/SATS/SwiftUI Screen.xctemplate/___FILEBASENAME___AdapterController.swift
@@ -12,8 +12,6 @@ class ___VARIABLE_adapterController___: UIViewController, AdapterController {
         UIHostingController(rootView: ___VARIABLE_stateView___(viewModel: viewModel))
     }()
 
-    func buildHostedView() -> ___VARIABLE_stateView___ { ___VARIABLE_stateView___(viewModel: viewModel) }
-
     // MARK: Initializers
 
     init() {

--- a/Templates/SATS/SwiftUI Screen.xctemplate/___FILEBASENAME___ViewModel.swift
+++ b/Templates/SATS/SwiftUI Screen.xctemplate/___FILEBASENAME___ViewModel.swift
@@ -13,16 +13,16 @@ class ___VARIABLE_viewModel___: ObservableObject {
         self.state = state
     }
 
-    @MainActor func initialLoad() async {
+    func initialLoad() async {
         guard case .idle = state else { return }
         await fetchData()
     }
 
-    @MainActor func reloadData() async {
+    func reloadData() async {
         await fetchData()
     }
 
-    private func fetchData() async {
+    @MainActor private func fetchData() async {
         state = .loading
 
         do {


### PR DESCRIPTION
The idea was this was gonna be used to set the type for UIHostingController, but this is not necessary as we are using Associated types

This was removed from the `AdapterController` protocol